### PR TITLE
Ensure testing recent image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ defaults: &defaults
 
 python_defaults: &python_defaults
   docker:
-    - image: quay.io/encode-dcc/demo-pipeline:template
+    - image: quay.io/encode-dcc/demo-pipeline:${CIRCLE_BRANCH}_${CIRCLE_WORKFLOW_ID}
   working_directory: ~/demo-pipeline
  
 machine_defaults: &machine_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,12 +68,13 @@ jobs:
     <<: *machine_defaults
     steps:
       - checkout
+      - run: *make_tag
       - run: *get_cromwell
       - run:
           command: |
             pyenv global 3.5.2
-            java -jar cromwell-35.jar run test/test_task/test_trim.wdl -i test/test_task/test_trim.json -m metadata.json
-            python3 src/compare_md5.py --keys_to_inspect trim.trimmed_fastq --metadata_json metadata.json --reference_json test/test_task/ref_output/test_trim_output_md5.json --outfile result.json
+            test/test.sh test/test_task/test_trim.wdl test/test_task/test_trim.json $TAG docker
+            python3 src/compare_md5.py --keys_to_inspect trim.trimmed_fastq --metadata_json test_trim.metadata.json --reference_json test/test_task/ref_output/test_trim_output_md5.json --outfile result.json
             cat result.json
             python3 -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data['match_overall']))" < result.json
             
@@ -81,6 +82,7 @@ jobs:
     <<: *machine_defaults
     steps:
       - checkout
+      - run: *make_tag
       - run: *get_cromwell
       - run:
           command: |
@@ -94,6 +96,7 @@ jobs:
     <<: *machine_defaults
     steps:
       - checkout
+      - run: *make_tag
       - run: *get_cromwell
       - run:
           command: |
@@ -107,6 +110,7 @@ jobs:
     <<: *machine_defaults
     steps:
       - checkout
+      - run: *make_tag
       - run: *get_cromwell
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
       - run:
           command: |
             pyenv global 3.5.2
+            source ${BASH_ENV}
             test/test.sh test/test_task/test_trim.wdl test/test_task/test_trim.json $TAG docker
             python3 src/compare_md5.py --keys_to_inspect trim.trimmed_fastq --metadata_json test_trim.metadata.json --reference_json test/test_task/ref_output/test_trim_output_md5.json --outfile result.json
             cat result.json
@@ -87,8 +88,9 @@ jobs:
       - run:
           command: |
             pyenv global 3.5.2
-            java -jar cromwell-35.jar run test/test_task/test_plot.wdl -i test/test_task/test_plot.json -m metadata.json
-            python3 src/compare_md5.py --keys_to_inspect plot.plot_output --metadata_json metadata.json --reference_json test/test_task/ref_output/test_plot_output_md5.json --outfile result.json
+            source ${BASH_ENV}
+            test/test.sh test/test_task/test_plot.wdl test/test_task/test_plot.json $TAG docker
+            python3 src/compare_md5.py --keys_to_inspect plot.plot_output --metadata_json test_plot.metadata.json --reference_json test/test_task/ref_output/test_plot_output_md5.json --outfile result.json
             cat result.json
             python3 -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data['match_overall']))" < result.json
  
@@ -101,8 +103,9 @@ jobs:
       - run:
           command: |
             pyenv global 3.5.2
-            java -jar cromwell-35.jar run toy.wdl -i test/test_workflow/test_entrypoint.json -m metadata.json
-            python3 src/compare_md5.py --keys_to_inspect toy.trimmed_output --metadata_json metadata.json --reference_json test/test_workflow/ref_output/test_entrypoint_output_md5.json --outfile result.json
+            source ${BASH_ENV}
+            test/test.sh toy.wdl test/test_workflow/test_entrypoint.json $TAG docker
+            python3 src/compare_md5.py --keys_to_inspect toy.trimmed_output --metadata_json test_entrypoint.metadata.json --reference_json test/test_workflow/ref_output/test_entrypoint_output_md5.json --outfile result.json
             cat result.json
             python3 -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data['match_overall']))" < result.json
 
@@ -115,8 +118,9 @@ jobs:
       - run:
           command: |
             pyenv global 3.5.2
-            java -jar cromwell-35.jar run toy.wdl -i test/test_workflow/test_workflow.json -m metadata.json
-            python3 src/compare_md5.py --keys_to_inspect toy.trimmed_output toy.plots --metadata_json metadata.json --reference_json test/test_workflow/ref_output/test_workflow_output_md5.json --outfile result.json
+            source ${BASH_ENV}
+            test/test.sh toy.wdl test/test_workflow/test_workflow.json $TAG docker
+            python3 src/compare_md5.py --keys_to_inspect toy.trimmed_output toy.plots --metadata_json test_workflow.metadata.json --reference_json test/test_workflow/ref_output/test_workflow_output_md5.json --outfile result.json
             cat result.json
             python3 -c "import sys; import json; data=json.loads(sys.stdin.read()); sys.exit(int(not data['match_overall']))" < result.json
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -e # exit on error
+
+WDL=$1
+INPUT=$2
+DOCKER_IMAGE=$3
+CROMWELL_JAR=cromwell-35.jar
+BACKEND_CONF=backends/backend.conf
+RESULT_PREFIX=$(basename ${INPUT} .json)
+METADATA=${RESULT_PREFIX}.metadata.json # metadata
+RESULT=${RESULT_PREFIX}.result.json # output
+
+if [ $4 = "docker" ]; then
+    # Write workflow option JSON file for docker
+    BACKEND=Local
+    TMP_WF_OPT=$RESULT_PREFIX.test_toy_wf_opt.json
+    cat > $TMP_WF_OPT << EOM
+    {
+        "default_runtime_attributes" : {
+            "docker" : "$DOCKER_IMAGE"
+        }
+    }
+EOM
+fi
+
+if [ $4 = "singularity" ]; then
+    #build singularity container
+    SINGULARITY_PULLFOLDER=~/.singularity singularity pull docker://${DOCKER_IMAGE}
+    # Write workflow option JSON file for singularity
+    BACKEND=singularity
+    TMP_WF_OPT=$RESULT_PREFIX.test_toy_wf_opt.json
+    SINGULARITY_IMAGE=$(echo ${DOCKER_IMAGE} | sed 's/quay\.io\/encode-dcc\///g' | sed 's/:/-/' | sed 's/$/\.simg/')
+    cat > $TMP_WF_OPT << EOM
+    {
+        "default_runtime_attributes" : {
+            "singularity_container" : "~/.singularity/$SINGULARITY_IMAGE"
+        }
+    }
+EOM
+fi
+
+java -Dconfig.file=${BACKEND_CONF} -Dbackend.default=${BACKEND} -jar ${CROMWELL_JAR} run ${WDL} -i ${INPUT} -o ${TMP_WF_OPT} -m ${METADATA}
+
+rm -f ${TMP_WF_OPT}


### PR DESCRIPTION
I added a script test/test.sh that will ensure that the image that is tested is the one whose $TAG is the one created in the build step. This prevents a surgically timed quay.io push from other build step to cause the tests to use wrong image.