### PR TITLE
update docs to fix singularity pull folder issue

### DIFF
--- a/docs/tutorial_local_singularity.md
+++ b/docs/tutorial_local_singularity.md
@@ -4,7 +4,7 @@
 
 2. Build the singularity image for the pipeline. The following pulls the pipeline docker image, and uses that to construct the singularity image. The image will be stored in `~/.singularity`.
 ```
-$ SINGULARITY_PULLFOLDER=~/.singularity singularity pull docker://quay.io/encode-dcc/demo-pipeline:template
+$ SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull docker://quay.io/encode-dcc/demo-pipeline:template
 ```
 
 3. Get the code and move to the repo directory:

--- a/docs/tutorial_scg.md
+++ b/docs/tutorial_scg.md
@@ -29,7 +29,7 @@ Tutorial for Stanford SCG cluster
 
 5. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`.
     ```
-      $ SINGULARITY_PULLFOLDER=~/.singularity singularity pull docker://quay.io/encode-dcc/demo-pipeline:template
+      $ SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull docker://quay.io/encode-dcc/demo-pipeline:template
     ```
 
 6. Run a pipeline for the test sample.

--- a/docs/tutorial_sherlock.md
+++ b/docs/tutorial_sherlock.md
@@ -35,7 +35,7 @@ Tutorial for Stanford Sherlock 2.0 cluster
 6. Pull a singularity container for the pipeline. This will pull pipeline's docker container first and build a singularity one on `~/.singularity`. Stanford Sherlock does not allow building a container on login nodes. Wait until you get a command prompt after `sdev`.
     ```
       $ sdev    # sherlock cluster does not allow building a container on login node
-      $ SINGULARITY_PULLFOLDER=~/.singularity singularity pull docker://quay.io/encode-dcc/demo-pipeline:template
+      $ SINGULARITY_CACHEDIR=~/.singularity SINGULARITY_PULLFOLDER=~/.singularity singularity pull docker://quay.io/encode-dcc/demo-pipeline:template
       $ exit    # exit from an interactive node
     ```
 


### PR DESCRIPTION
Fix for issue #15 .

Singularity looks for SINGULARITY_CACHEDIR first. On Sherlock, default cache dir is on user's scratch.
```
[leepc12@sh-ln07 login! ~]$ echo $SINGULARITY_CACHEDIR
/scratch/users/leepc12/.singularity
[leepc12@sh-ln07 login! ~]$
```